### PR TITLE
Added two decorators for profiling memory

### DIFF
--- a/decorify/profiling.py
+++ b/decorify/profiling.py
@@ -6,7 +6,7 @@ import sys
 from typing import List, Literal, Optional, Callable, Any
 from decorify.base import decorator
 import gc # python garbage collector
-import tracemalloc
+import tracemalloc # python memory profiler
 
 
 def generate_ascii_tree(item, prefix='', is_last=False, is_root=True):
@@ -153,14 +153,20 @@ def crawler(c_calls: bool = False, show_dunder_methods: bool = True, return_type
 
 def track_leaks(__func__: Callable[..., Any]) -> Callable[..., tuple[Any, int]]:
     """Decorator for finding memory leaks. 
-    It utilizes Python's gc module to track objects before and after function call.
-    The decorator returns a tuple of function's output and number of leaked objects.
+    It utilizes Python's gc module to track objects before and after function 
+    call. The decorator returns a tuple of function's output and number of 
+    leaked objects.
 
-    Args:
-        __func__ (Callable[..., Any], optional): The function to wrap. Defaults to None.
+    Parameters
+    ----------
+    __func__: Callable[..., Any] 
+        The function to wrap. Defaults to None.
 
-    Returns:
-        Callable[..., tuple[Any, int]]: Wrapped function that returns a tuple of function's output and number of leaked objects.
+    Returns
+    -------
+    Callable[..., tuple[Any, int]]
+        Wrapped function that returns a tuple of function's output and number of
+        leaked objects.
     """
     @wraps(__func__)
     def inner_func(*args, **kwargs) -> tuple[Any, int]:
@@ -179,14 +185,17 @@ def track_leaks(__func__: Callable[..., Any]) -> Callable[..., tuple[Any, int]]:
     return inner_func
 
 def measure_memory_usage(__func__: Callable[..., Any]) -> Callable[..., tuple[Any, int]]:
-    """Decorator for measuring memory usage. 
-    The decorator returns a tuple of function's output and peak memory usage in bytes.
+    """Decorator for measuring memory usage. The decorator returns a tuple of 
+    function's output and peak memory usage in bytes.
 
     Args:
-        __func__ (Callable[..., Any], optional): The function to wrap. Defaults to None.
+    __func__: Callable[..., Any]
+        The function to wrap. Defaults to None.
 
     Returns:
-        Callable[..., tuple[Any, int]]: Wrapped function that returns a tuple of function's output and memory usage in bytes.
+    Callable[..., tuple[Any, int]]
+        Wrapped function that returns a tuple of function's output and memory 
+        usage in bytes.
     """
     @wraps(__func__)
     def inner_func(*args, **kwargs) -> tuple[Any, int]:

--- a/decorify/profiling.py
+++ b/decorify/profiling.py
@@ -3,8 +3,10 @@ from functools import wraps
 import logging
 import traceback
 import sys
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Callable, Any
 from decorify.base import decorator
+import gc # python garbage collector
+import tracemalloc
 
 
 def generate_ascii_tree(item, prefix='', is_last=False, is_root=True):
@@ -148,3 +150,53 @@ def crawler(c_calls: bool = False, show_dunder_methods: bool = True, return_type
         return res
 
     return inner
+
+def track_leaks(__func__: Callable[..., Any]) -> Callable[..., tuple[Any, int]]:
+    """Decorator for finding memory leaks. 
+    It utilizes Python's gc module to track objects before and after function call.
+    The decorator returns a tuple of function's output and number of leaked objects.
+
+    Args:
+        __func__ (Callable[..., Any], optional): The function to wrap. Defaults to None.
+
+    Returns:
+        Callable[..., tuple[Any, int]]: Wrapped function that returns a tuple of function's output and number of leaked objects.
+    """
+    @wraps(__func__)
+    def inner_func(*args, **kwargs) -> tuple[Any, int]:
+        # enable garbage collector
+        gc_enabled = gc.isenabled()
+        if not gc_enabled:
+            gc.enable()
+        # track objects
+        tracked = len(gc.get_objects())
+        result = __func__(*args, **kwargs)
+        # find leaked objects
+        leaked = len(gc.get_objects()) - tracked
+        if not gc_enabled:
+            gc.disable()
+        return result, leaked
+    return inner_func
+
+def measure_memory_usage(__func__: Callable[..., Any]) -> Callable[..., tuple[Any, int]]:
+    """Decorator for measuring memory usage. 
+    The decorator returns a tuple of function's output and peak memory usage in bytes.
+
+    Args:
+        __func__ (Callable[..., Any], optional): The function to wrap. Defaults to None.
+
+    Returns:
+        Callable[..., tuple[Any, int]]: Wrapped function that returns a tuple of function's output and memory usage in bytes.
+    """
+    @wraps(__func__)
+    def inner_func(*args, **kwargs) -> tuple[Any, int]:
+        tracing = tracemalloc.is_tracing()
+        if not tracing:
+            tracemalloc.start()
+        start_current, _ = tracemalloc.get_traced_memory()
+        result = __func__(*args, **kwargs)
+        _, peak = tracemalloc.get_traced_memory()
+        if not tracing:
+            tracemalloc.stop()
+        return result, peak - start_current
+    return inner_func

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,4 +1,5 @@
-from decorify.profiling import crawler, Tree, generate_ascii_tree
+from decorify.profiling import crawler, Tree, generate_ascii_tree, track_leaks, measure_memory_usage
+import sys
 
 
 def test_profiling_stack():
@@ -39,3 +40,36 @@ def test_ascii_generator():
         'add_2', ['add_2'], ['add_2']]], ['add_2', ['add_2', ['add_2'], ['add_2']], ['add_2']]]]
     ascii_tree = generate_ascii_tree(sample)
     assert isinstance(ascii_tree, str)
+
+def test_track_leaks():
+    @track_leaks
+    def func_a():
+        return sum([1, 1])
+    
+    _, leaked = func_a()
+    assert leaked == 0
+    
+    # I have heard this is a memory leak, but I am not sure if it actually is
+    # this decorator sure thinks it is
+    # MAYBE create our own bad C mini extension with a memory leak and test it.
+    @track_leaks
+    def func_leak():
+        try:
+            raise Exception
+        except Exception as e:
+            etype, evalue, tb = sys.exc_info()
+            return tb
+        
+    _, leaked = func_leak()
+    assert leaked == 3
+    
+def test_track_memory():
+    
+    @measure_memory_usage
+    def func_a():
+        return 1
+    
+    ret, memory = func_a()
+    ret_size = sys.getsizeof(ret)
+    assert memory >= ret_size
+    


### PR DESCRIPTION
I have added two new decorators. One that measures how many objects gc lost track of (memory leaks) and another that uses tracemalloc to benchmark allocated memory